### PR TITLE
fix: panic if loading config fails, if no envsetrc use default byte string

### DIFF
--- a/cmd/envset/main.go
+++ b/cmd/envset/main.go
@@ -21,8 +21,6 @@ var app *cli.App
 var cnf *config.Config
 
 func init() {
-	cnf, _ = config.Load(".envsetrc")
-
 	cli.VersionFlag = &cli.BoolFlag{
 		Name:    "version",
 		Aliases: []string{"V"},
@@ -52,6 +50,11 @@ func main() {
 }
 
 func run(args []string) {
+	cnf, err := config.Load(".envsetrc")
+	if err != nil {
+		log.Println("Error loading configuration:", err)
+		log.Panic("Ensure you have a valid .envsetrc")
+	}
 
 	subcommands := []*cli.Command{}
 
@@ -311,7 +314,7 @@ func run(args []string) {
 		return envset.Run(env, filename, cmd, arg, isolated, expand, required)
 	}
 
-	err := app.Run(args)
+	err = app.Run(args)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,12 +30,18 @@ type Config struct {
 
 //Load returns configuration object from `.envsetrc` file
 func Load(name string) (*Config, error) {
-	filename, err := envset.FileFinder(name)
-	if err != nil {
-		return &Config{}, err
-	}
+	var err error
+	var cfg *ini.File
+	var filename string
 
-	cfg, err := ini.ShadowLoad(filename, config)
+	filename, _ = envset.FileFinder(name)
+
+	if filename == "" {
+		cfg, err = ini.ShadowLoad(config)
+	} else {
+		cfg, err = ini.ShadowLoad(filename, config)
+	}
+	
 	if err != nil {
 		return &Config{}, err
 	}


### PR DESCRIPTION
This closes #6

When provided path to `.envsetrc` finds no file:
- Use default byte string with a basic `.envsetrc`

In case our config load function returns an error:
- Print error and panic

For the time being we will not add a command to generate a sample config file.