### PR TITLE
Check we have a command string

### DIFF
--- a/pkg/envset/envmap.go
+++ b/pkg/envset/envmap.go
@@ -145,8 +145,13 @@ func interpolateCmds(str string, vars map[string]string) (string, error) {
 		command := strings.Replace(match, ")", "", -1)
 		command = strings.Replace(command, "$(", "", -1)
 
+		if len(command) == 0 {
+			continue
+		}
+
 		//Some commands might have arguments: $(hostname -f)
 		args := strings.Split(command, " ")
+
 		res, err := exec.Command(args[0], args[1:]...).Output()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
Quick fix for #10 by checking we actually have a command string before executing the command.