### PR TITLE
Refactor config and add support for (alternative) dot env files

### DIFF
--- a/cmd/envset/main.go
+++ b/cmd/envset/main.go
@@ -45,11 +45,12 @@ func init() {
 }
 
 func main() {
-
-	run(os.Args)
+	a := cliArgs(os.Args)
+	c := cmdFromArgs(os.Args)
+	run(a, c)
 }
 
-func run(args []string) {
+func run(args []string, exec execCmd) {
 	cnf, err := config.Load(".envsetrc")
 	if err != nil {
 		log.Println("Error loading configuration:", err)
@@ -64,51 +65,59 @@ func run(args []string) {
 			Usage:       fmt.Sprintf("load \"%s\" environment in current shell session", env),
 			UsageText:   fmt.Sprintf("envset %s [options] -- [command] [arguments...]", env),
 			Description: "This will load the environment and execute the provided command",
-			// ArgsUsage:   "[arrgh]",
-			Category: "ENVIRONMENTS",
+			Category:    "ENVIRONMENTS",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "isolated",
 					Usage: "if true we run shell with only variables defined",
-					Value: true, //call with --isolated=false to show all
+					Value: cnf.Isolated, //call with --isolated=false to show all
 				},
 				&cli.BoolFlag{
 					Name:  "expand",
 					Usage: "if true we use expand environment variables",
-					Value: true, //call with --isolated=false to show all
+					Value: cnf.Expand,
 				},
 				&cli.StringFlag{
 					Name:  "env-file",
 					Usage: "file name with environment definition",
-					Value: ".envset",
+					Value: cnf.Filename,
 				},
 				&cli.StringSliceFlag{
 					Name:    "required",
 					Aliases: []string{"R"},
 					Usage:   "list of key names that are required to run",
 				},
+				&cli.StringFlag{
+					Name:    "export-env-name",
+					Aliases: []string{"N"},
+					Usage:   "name of exported variable with current environment name",
+					Value:   cnf.ExportEnvName,
+				},
 			},
 			Action: func(c *cli.Context) error {
-				expand := c.Bool("expand")
-				isolated := c.Bool("isolated")
 				//TODO: we want to support .env.local => [local]
-				filename := c.String("env-file")
+
 				env := c.Command.Name
+
+				ro := envset.RunOptions{
+					Cmd:           exec.Cmd,
+					Args:          exec.Args,
+					Isolated:      c.Bool("isolated"),
+					Expand:        c.Bool("expand"),
+					Required:      c.StringSlice("required"),
+					Filename:      c.String("env-file"),
+					ExportEnvName: c.String("export-env-name"),
+				}
 
 				if c.NArg() == 0 {
 					//we can do: eval `envset development`
 					//we can do: envset development > /tmp/env1 | source
 					//https://stackoverflow.com/questions/36074851/persist-the-value-set-for-an-env-variable-on-the-shell-after-the-go-program-exit
 					//TODO: Pass required so we show missing ones?
-					return envset.Print(env, filename, isolated, expand)
+					return envset.Print(env, ro.Filename, ro.Isolated, ro.Expand)
 				}
 
-				cmd := c.Args().First()
-				arg := c.Args().Slice()[1:]
-
-				//TODO: Get from config
-				required := c.StringSlice("required")
-				return envset.Run(env, filename, cmd, arg, isolated, expand, required)
+				return envset.Run(env, ro)
 			},
 		})
 	}
@@ -119,13 +128,13 @@ func run(args []string) {
 		Description: "creates a metadata file with all the given environments",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{Name: "print", Usage: "only print the contents to stdout, don't write file"},
-			&cli.StringFlag{Name: "filename", Usage: "metadata file name", Value: "metadata.json"},
-			&cli.StringFlag{Name: "filepath", Usage: "metadata file path", Value: "./.envmeta"},
-			&cli.StringFlag{Name: "env-file", Value: ".envset", Usage: "load environment from `FILE`"},
+			&cli.StringFlag{Name: "filename", Usage: "metadata file `name`", Value: cnf.Meta.File},
+			&cli.StringFlag{Name: "filepath", Usage: "metadata file `path`", Value: cnf.Meta.Dir},
+			&cli.StringFlag{Name: "env-file", Value: cnf.Filename, Usage: "load environment from `FILE`"},
 			&cli.BoolFlag{Name: "overwrite", Usage: "set true to prevent overwrite metadata file", Value: true},
 			&cli.BoolFlag{Name: "values", Usage: "add flag to show values in the output"},
 			&cli.BoolFlag{Name: "globals", Usage: "include global section", Value: false},
-			&cli.StringFlag{Name: "secret", Usage: "secret used to encode hash values", EnvVars: []string{"ENVSET_HASH_SECRET"}},
+			&cli.StringFlag{Name: "secret", Usage: "`password` used to encode hash values", EnvVars: []string{"ENVSET_HASH_SECRET"}},
 		},
 		Action: func(c *cli.Context) error {
 			print := c.Bool("print")
@@ -239,9 +248,9 @@ func run(args []string) {
 		Description: "create a new template or update file to document the variables in your environment",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{Name: "print", Usage: "only print the contents to stdout, don't write file"},
-			&cli.StringFlag{Name: "filename", Usage: "template file name", Value: "envset.example"},
-			&cli.StringFlag{Name: "filepath", Usage: "template file path", Value: "."},
-			&cli.StringFlag{Name: "env-file", Value: ".envset", Usage: "load environment from `FILE`"},
+			&cli.StringFlag{Name: "filename", Usage: "template file `name`", Value: cnf.Template.File},
+			&cli.StringFlag{Name: "filepath", Usage: "template file `path`", Value: cnf.Template.Path},
+			&cli.StringFlag{Name: "env-file", Value: cnf.Filename, Usage: "load environment from `FILE`"},
 			&cli.BoolFlag{Name: "overwrite", Usage: "overwrite file, this will delete any changes"},
 		},
 		Action: func(c *cli.Context) error {
@@ -272,19 +281,25 @@ func run(args []string) {
 
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
+			Name:  "env",
+			Usage: "env name matching a section. If not set matches env vars in global scope",
+			Value: envset.DefaultSection,
+		},
+		&cli.StringFlag{
 			//This can be an absolute path. If a file name then we recursively look up
 			Name:  "env-file",
-			Usage: "file with environment definition",
+			Usage: "`file` with environment definition",
+			Value: cnf.Filename,
 		},
 		&cli.BoolFlag{
 			Name:  "isolated",
-			Usage: "if true we run shell with only variables defined",
-			Value: true, //call with --isolated=false to show all
+			Usage: "if false the environment inherits the shell's environment",
+			Value: cnf.Isolated, //call with --isolated=false to show all
 		},
 		&cli.BoolFlag{
 			Name:  "expand",
-			Usage: "if true we expand environment variables defined",
-			Value: true, //call with --isolated=false to show all
+			Usage: "if true we expand environment variables",
+			Value: cnf.Expand,
 		},
 		&cli.StringSliceFlag{
 			Name:    "required",
@@ -294,26 +309,45 @@ func run(args []string) {
 	}
 
 	app.Action = func(c *cli.Context) error {
-		expand := c.Bool("expand")
-		filename := c.String("env-file")
-		isolated := c.Bool("isolated")
 
-		if filename == "" {
+		//How do we end up here?
+		//If we try to execute a command for an inexistent environment, e.g:
+		// envset ==> show help
+		//we just called: envset
+		if c.NArg() == 0 && c.NumFlags() == 0 {
 			cli.ShowAppHelpAndExit(c, 0)
 		}
 
-		env := envset.DefaultSection
-		if c.NArg() == 0 {
-			return envset.Print(env, filename, isolated, expand)
+		env := c.String("env")
+
+		o := envset.RunOptions{
+			Cmd:      exec.Cmd,
+			Args:     exec.Args,
+			Expand:   c.Bool("expand"),
+			Isolated: c.Bool("isolated"),
+			Filename: c.String("env-file"),
+		}
+		//Run if we have something like this:
+		// envset --env-file=.env -- node index.js
+		// envset --env-file=.envset --env=development -- node index.js
+		if exec.Cmd != "" && o.Filename != cnf.Filename {
+			return envset.Run(env, o)
 		}
 
-		cmd := c.Args().First()
-		arg := c.Args().Slice()[1:]
+		// envset undefined ==> show error: environment undefined does not exist
+		// envset undefined -- node index.js ==> show error: environment undefined does not exist
+		if c.NArg() >= 1 && !c.Command.HasName(c.Args().First()) {
+			return cli.Exit(fmt.Sprintf("%s: not a valid environment name", c.Args().First()), 1)
+		}
 
-		required := c.StringSlice("required")
-		return envset.Run(env, filename, cmd, arg, isolated, expand, required)
+		//we called something like:
+		//envset --env-file=.env
+		//envset --env-file=.envset --env=development
+		return envset.Print(env, o.Filename, o.Isolated, o.Expand)
 	}
 
+	//TODO: we should process args to remove executable context
+	//and return the arguments that are only for envset
 	err = app.Run(args)
 	if err != nil {
 		log.Fatal(err)
@@ -322,4 +356,43 @@ func run(args []string) {
 
 func appendCommand(command *cli.Command) {
 	app.Commands = append(app.Commands, command)
+}
+
+type execCmd struct {
+	Cmd  string
+	Args []string
+}
+
+func cmdFromArgs(args []string) execCmd {
+	cmd := ""
+	idx := 0
+	a := make([]string, 0)
+
+	for i, v := range args {
+		if v == "--" {
+			idx = i + 1
+			break
+		}
+	}
+
+	if idx > 0 && len(args) >= idx {
+		a = args[idx:]
+	}
+
+	return execCmd{
+		Cmd:  cmd,
+		Args: a,
+	}
+}
+
+func cliArgs(args []string) []string {
+	o := make([]string, 0)
+	for _, v := range args {
+		if v == "--" {
+			break
+		}
+		o = append(o, v)
+	}
+
+	return o
 }

--- a/cmd/envset/main_test.go
+++ b/cmd/envset/main_test.go
@@ -1,13 +1,12 @@
 package main
 
-import(
+import (
 	"os"
 	"testing"
 )
 
-
 func Test_CommandHelp(t *testing.T) {
 	args := os.Args[0:1]
-	args = append(args, "-h") 
-	run(args)
+	args = append(args, "-h")
+	run(args, execCmd{})
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,7 +10,17 @@ import (
 
 var config = []byte(`
 filename=.envset
+expand=true
 isolated=true
+export_environment=APP_ENV
+
+[metadata]
+dir=.meta
+file=data.json
+
+[template]
+path=.
+file=envset.example
 
 [environments]
 name=test
@@ -25,7 +35,18 @@ type Config struct {
 	Environments struct {
 		Name []string `ini:"name,omitempty,allowshadow"`
 	} `ini:"environments"`
-	Created time.Time `ini:"-"`
+	Created       time.Time `ini:"-"`
+	Expand        bool      `ini:"expand"`
+	Isolated      bool      `ini:"isolated"`
+	ExportEnvName string    `ini:"export_environment"`
+	Meta          struct {
+		Dir  string `ini:"dir"`
+		File string `ini:"file"`
+	} `ini:"metadata"`
+	Template struct {
+		Path string `ini:"path"`
+		File string `ini:"file"`
+	} `ini:"template"`
 }
 
 //Load returns configuration object from `.envsetrc` file
@@ -41,7 +62,7 @@ func Load(name string) (*Config, error) {
 	} else {
 		cfg, err = ini.ShadowLoad(filename, config)
 	}
-	
+
 	if err != nil {
 		return &Config{}, err
 	}


### PR DESCRIPTION
This closes #14 and #13.

We now support alternative environment files, e.g. dot env files:

```
$ envset --env-file=.env -- node index.js
```