### PR TITLE
add: inherit flag, we will pull these env vars from parent environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-10]
         go: ["1.17"]
     env:
       VERBOSE: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10]
+        os: [ubuntu-latest, macos-latest]
         go: ["1.17"]
     env:
       VERBOSE: 1

--- a/README.md
+++ b/README.md
@@ -90,10 +90,34 @@ $ envset development -- say \${MSG}
 
 #### Inherit environment
 
+You can control environment inheritance using two flags:
+
+- `--isolated`
+- `--inherit`
+
 By default `envset` will run commands in a clean environment. Sometimes you want the executed command to access the host's environment. To do so you need to pass the `--isolated=false` flag.
 
 ```console
 $ envset development --isolated=false -- spd-say '${APP_NAME}' 
+```
+
+Some commands might rely on environment variables set on your shell, for instance if you want to `go run`:
+
+```console
+$ envset development -- go run cmd/app/server.go
+missing $GOPATH
+```
+You will get an error saying that `$GOPATH` is not available. You should run the command with the `--isolated=false`:
+
+```console
+$ envset development --isolated=false -- go run cmd/app/server.go
+```
+
+The `-inherit` flag lets you specify a list of environment variable keys that will be inherited from the parent environment.
+
+In the previous example instead of exposing the whole parent environment we could just expose `$GOPATH`:
+``console
+$ envset development -I=GOPATH -I=HOME -- go run cmd/app/server.go
 ```
 
 #### Load env file to current shell session

--- a/cmd/envset/main.go
+++ b/cmd/envset/main.go
@@ -93,6 +93,11 @@ func run(args []string, exec execCmd) {
 					Usage:   "name of exported variable with current environment name",
 					Value:   cnf.ExportEnvName,
 				},
+				&cli.StringSliceFlag{
+					Name:    "inherit",
+					Aliases: []string{"I"},
+					Usage:   "list of env vars to inherit from shell",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				//TODO: we want to support .env.local => [local]
@@ -105,6 +110,7 @@ func run(args []string, exec execCmd) {
 					Isolated:      c.Bool("isolated"),
 					Expand:        c.Bool("expand"),
 					Required:      c.StringSlice("required"),
+					Inherit:       c.StringSlice("inherit"),
 					Filename:      c.String("env-file"),
 					ExportEnvName: c.String("export-env-name"),
 				}

--- a/pkg/envset/envset.go
+++ b/pkg/envset/envset.go
@@ -22,6 +22,7 @@ type RunOptions struct {
 	Isolated      bool
 	Expand        bool
 	Required      []string
+	Inherit       []string
 	ExportEnvName string
 }
 
@@ -109,7 +110,12 @@ func Run(environment string, options RunOptions) error {
 	//our variables from the loaded file
 	if options.Isolated {
 		command.Env = vars
-		//we actually add our context to the os
+		//add value for any inherited env vars we have in options
+		for _, k := range options.Inherit {
+			if v := os.Getenv(k); v != "" {
+				command.Env = append(command.Env, fmt.Sprintf("%s=%s", k, v))
+			}
+		}
 	} else {
 
 		local := LocalEnv()


### PR DESCRIPTION
This PR will add a new flag `-inherit` which will be a list of inherited environment variables we pull from the parent environment.

```console
$ envset development -I=GOPATH -I=HOME -- go run cmd/app/server.go
```