### PR TITLE
Add `metadata config get` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@
 * [Environment level configuration](#Environmentlevelconfiguration)
 * [Similar Tools](#SimilarTools)
 * [Examples](#Examples)
-	* [Executing a command](#Executingacommand)
-		* [Variable substitution](#Variablesubstitution)
-		* [Inherit environment](#Inheritenvironment)
-		* [Load env file to current shell session](#Loadenvfiletocurrentshellsession)
-		* [Required environment variables](#Requiredenvironmentvariables)
-	* [Generating an example template](#Generatinganexampletemplate)
-	* [Support for .env files](#Supportfor.envfiles)
+	* [Executing A Command](#ExecutingACommand)
+		* [Variable Substitution](#VariableSubstitution)
+		* [Inherit Environment](#InheritEnvironment)
+		* [Overwriting Variables At Runtime](#OverwritingVariablesAtRuntime)
+		* [Load Env File To Current Shell Session](#LoadEnvFileToCurrentShellSession)
+		* [Required Environment Variables](#RequiredEnvironmentVariables)
+	* [Generating An Example Template](#GeneratingAnExampleTemplate)
+	* [Support For .env Files](#SupportFor.envFiles)
 	* [Metadata](#Metadata)
 	* [Metadata Compare](#MetadataCompare)
 		* [Ignore Variables](#IgnoreVariables)
@@ -27,7 +28,7 @@
 	* [Commands](#Commands)
 	* [Variable Expansion](#VariableExpansion)
 	* [Commands](#Commands-1)
-* [.envset file](#envsetfile)
+* [.envset File](#envsetFile)
 * [.envsetrc](#envsetrc)
 	* [Configuration](#Configuration)
 	* [Configuration Syntax](#ConfigurationSyntax)
@@ -85,7 +86,7 @@ Instead of having an `.env` file per environment you can have one single `.envse
 
 ## <a name='Examples'></a>Examples
 
-### <a name='Executingacommand'></a>Executing a command
+### <a name='ExecutingACommand'></a>Executing A Command
 
 An **.envset** file could look like this:
 
@@ -116,7 +117,7 @@ To use it, simply prefix the call to your program with `envset` and the name of 
 $ envset development -- node app.js
 ```
 
-#### <a name='Variablesubstitution'></a>Variable substitution
+#### <a name='VariableSubstitution'></a>Variable Substitution
 
 You can execute commands that use environment variables in the command arguments.
 
@@ -127,7 +128,7 @@ $ envset development -- say '${MSG}'
 $ envset development -- say \${MSG}
 ```
 
-#### <a name='Inheritenvironment'></a>Inherit environment
+#### <a name='InheritEnvironment'></a>Inherit Environment
 
 You can control environment inheritance using two flags:
 
@@ -159,7 +160,15 @@ In the previous example instead of exposing the whole parent environment we coul
 $ envset development -I=GOPATH -I=HOME -- go run cmd/app/server.go
 ```
 
-#### <a name='Loadenvfiletocurrentshellsession'></a>Load env file to current shell session
+#### <a name='OverwritingVariablesAtRuntime'></a>Overwriting Variables At Runtime
+
+You can overwrite environment variables without editing your `.envset` file.
+
+```console
+APP_NAME="New Name" envset development --isolated=false -- spd-say '${APP_NAME}'
+```
+
+#### <a name='LoadEnvFileToCurrentShellSession'></a>Load Env File To Current Shell Session
 
 If you want to make the variables defined in a env file to your running shell session use something like the following snippet.
 
@@ -168,7 +177,7 @@ If you want to make the variables defined in a env file to your running shell se
 $ eval $(envset development)
 ```
 
-#### <a name='Requiredenvironmentvariables'></a>Required environment variables
+#### <a name='RequiredEnvironmentVariables'></a>Required Environment Variables
 
 You can specify a list of required environment variables for your command using the `--required` flag or its `-R` alias.
 
@@ -190,7 +199,7 @@ $ envset development --required=BOOM -R BOOM2 -- node index.js
 missing required keys: BOOM,BOOM2
 ```
 
-### <a name='Generatinganexampletemplate'></a>Generating an example template
+### <a name='GeneratingAnExampleTemplate'></a>Generating An Example Template
 
 If we run the `envset template` command with the previous **.envset** file we generate a **envset.example** file:
 
@@ -215,7 +224,7 @@ NODE_POSTGRES_USER={{NODE_POSTGRES_USER}}
 ```
 
 
-### <a name='Supportfor.envfiles'></a>Support for .env files
+### <a name='SupportFor.envFiles'></a>Support For .env Files
 
 You can load other environment files like `.env` files:
 
@@ -371,7 +380,7 @@ $ envset development -- node cli.js --user '${USER}'
 
 If you type `envset` without arguments it will display help and a list of supported environment names.
 
-## <a name='envsetfile'></a>.envset file
+## <a name='envsetFile'></a>.envset File
 
 
 ## <a name='envsetrc'></a>.envsetrc

--- a/cmd/envset/metadata/metadata.go
+++ b/cmd/envset/metadata/metadata.go
@@ -30,7 +30,7 @@ func GetCommand(cnf *config.Config) *cli.Command {
 			&cli.StringFlag{Name: "filename", Usage: "metadata file `name`", Value: cnf.Meta.File},
 			&cli.StringFlag{Name: "filepath", Usage: "metadata file `path`", Value: cnf.Meta.Dir},
 			&cli.StringFlag{Name: "env-file", Value: cnf.Filename, Usage: "load environment from `FILE`"},
-			&cli.BoolFlag{Name: "overwrite", Usage: "set true to prevent overwrite metadata file", Value: true},
+			&cli.BoolFlag{Name: "overwrite", Usage: "set to false to prevent overwrite metadata file", Value: true},
 			&cli.BoolFlag{Name: "values", Usage: "add flag to show values in the output"},
 			&cli.BoolFlag{Name: "globals", Usage: "include global section", Value: false},
 			&cli.StringFlag{Name: "secret", Usage: "`password` used to encode hash values", EnvVars: []string{"ENVSET_HASH_SECRET"}},

--- a/cmd/envset/rc/rc.go
+++ b/cmd/envset/rc/rc.go
@@ -11,7 +11,8 @@ import (
 //rc command.
 func GetCommand(cnf *config.Config) *cli.Command {
 	return &cli.Command{
-		Name:        "rc",
+		Name:        "config",
+		Aliases:     []string{"rc"},
 		Usage:       "generate an envsetrc file",
 		Description: "creates an envsetrc file with either the current options or the default options",
 		Flags: []cli.Flag{
@@ -37,6 +38,20 @@ func GetCommand(cnf *config.Config) *cli.Command {
 			fmt.Printf("%s", config.GetDefaultConfig())
 
 			return nil
+		},
+		Subcommands: []*cli.Command{
+			{
+				Name:        "get",
+				Usage:       "get option value for key",
+				UsageText:   "get option value for key",
+				Description: "retrieves configuration value of given key",
+				Action: func(c *cli.Context) error {
+					key := c.Args().First()
+					val := cnf.Get(key)
+					fmt.Println(val)
+					return nil
+				},
+			},
 		},
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path"
 	"time"
 
 	"github.com/goliatone/go-envset/pkg/envset"
@@ -121,6 +122,26 @@ func (c *Config) MergeRequired(section string, required []string) []string {
 	out := append(c.Required[section], required...)
 	//TODO: should we make them unique?
 	return out
+}
+
+//Get will return the value of the given key
+func (c *Config) Get(key string) string {
+	switch key {
+	case "filename":
+		return c.Filename
+	case "meta.dir":
+		return c.Meta.Dir
+	case "meta.file":
+		return c.Meta.File
+	case "meta.path":
+		return path.Join(c.Meta.Dir, c.Meta.File)
+	case "template.path":
+		return c.Template.Path
+	case "template.file":
+		return c.Template.File
+	default:
+		return ""
+	}
 }
 
 //GetDefaultConfig returns the default


### PR DESCRIPTION
This PR closes #39 as well as adding a `config get` sub-command to retrieve config values by key.