### PR TITLE
[fix] Print use same signature as Run

### DIFF
--- a/cmd/envset/environment/environment.go
+++ b/cmd/envset/environment/environment.go
@@ -70,7 +70,7 @@ func GetCommand(env string, ecmd exec.ExecCmd, cnf *config.Config) *cli.Command 
 			}
 
 			if ecmd.Cmd == "" {
-				return envset.Print(env, ro.Filename, ro.Isolated, ro.Expand)
+				return envset.Print(env, ro)
 			}
 
 			return envset.Run(env, ro)

--- a/cmd/envset/main.go
+++ b/cmd/envset/main.go
@@ -138,7 +138,7 @@ func run(args []string, ecmd exec.ExecCmd) {
 		//we called something like:
 		//envset --env-file=.env
 		//envset --env-file=.envset --env=development
-		return envset.Print(env, o.Filename, o.Isolated, o.Expand)
+		return envset.Print(env, o)
 	}
 
 	//TODO: we should process args to remove executable context

--- a/pkg/envset/envset.go
+++ b/pkg/envset/envset.go
@@ -92,7 +92,7 @@ func Run(environment string, options RunOptions) error {
 	vars := context.ToKVStrings()
 
 	//Replace '${VAR}' in the executable cmd arguments
-	//note that if these are not in single quited they will
+	//note that if these are not in single quotes they will
 	//be resolved by the shell when we call envset and we will
 	//read the the result of that replacement, even if is empty.
 	InterpolateKVStrings(options.Args, context, options.Expand)
@@ -134,8 +134,8 @@ func Run(environment string, options RunOptions) error {
 //Print will show the current environment
 //We don't need to do variable replacement if we print since
 //the idea is to use it as a source
-func Print(environment, name string, isolated, expand bool) error {
-	filename, err := FileFinder(name)
+func Print(environment string, options RunOptions) error {
+	filename, err := FileFinder(options.Filename)
 	if err != nil {
 		return fmt.Errorf("file finder: %w", err)
 	}
@@ -160,7 +160,7 @@ func Print(environment, name string, isolated, expand bool) error {
 
 	//we don't have any values here. Is that what the user
 	//wants?
-	if len(sec.KeyStrings()) == 0 && isolated {
+	if len(sec.KeyStrings()) == 0 && options.Isolated {
 		if environment == DefaultSection {
 			//running in DEFAULT but loaded an env file without a section name
 			for _, n := range names {
@@ -178,13 +178,13 @@ func Print(environment, name string, isolated, expand bool) error {
 	context := LoadIniSection(sec)
 
 	//Replace ${VAR} and $(command) in values
-	err = context.Expand(expand)
+	err = context.Expand(options.Expand)
 	if err != nil {
 		return fmt.Errorf("context expand: %w", err)
 	}
 
 	//----- actual print action
-	if isolated == false {
+	if options.Isolated == false {
 		for _, e := range os.Environ() {
 			fmt.Println(e)
 		}


### PR DESCRIPTION
Small refactoring to clean up the `envset.Print` signature to match `envset.Run`.